### PR TITLE
Highlight tmuxOptions as Special

### DIFF
--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -227,7 +227,7 @@ hi def link tmuxKey                 Special
 hi def link tmuxKeySymbol           Special
 hi def link tmuxNumber              Number
 hi def link tmuxSelWindowOption     Number
-hi def link tmuxOptions             Operator
+hi def link tmuxOptions             Special
 hi def link tmuxOptsSet             PreProc
 hi def link tmuxUserOptsSet         Identifier
 hi def link tmuxOptsSetw            PreProc


### PR DESCRIPTION
Hi,

I’ve noticed that options to commands (e.g. in shell scripts) tend to be highlighted in the `Special` group, while this plugin highlights these as `Operator`s.

Thanks.