### PR TITLE
Fix `bind \"` and `bind \'` commands syntax highlighting.

### DIFF
--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -161,6 +161,7 @@ syn keyword tmuxTodo FIXME NOTE TODO XXX todo contained
 syn match tmuxURL `\v<(((https?|ftp|gopher)://|(mailto|file|news):)[^'  <>"]+|(www|web|w3)[a-z0-9_-]*\.[a-z0-9._-]+\.[^'  <>"]+)[a-zA-Z0-9/]` contained
 
 syn match tmuxKey               /\(C-\|M-\|\^\)\+\S\+/  display
+syn match tmuxKey               /\\["']/                display
 syn match tmuxNumber            /\<[+-]\?\d\+/          display
 syn match tmuxSelWindowOption   /:[!+-]\?/              display
 syn match tmuxOptions           /\s-\a\+/               display


### PR DESCRIPTION
This PR adjusts the start expression for string regions to ignore an escaped single or double quote.  This resolves an issue where commands that unbind or bind the double quotation and single quotation keys would cause weird highlighting.

Without fix:
<img width="370" alt="image" src="https://user-images.githubusercontent.com/3019596/129936345-28915d29-cf0e-4054-b7a7-1090c8b47fe9.png">

With fix:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/3019596/129936317-1f51fcfa-786a-4289-bfd6-e0b1659c727a.png">
